### PR TITLE
update key

### DIFF
--- a/src/app-bundles/index.js
+++ b/src/app-bundles/index.js
@@ -69,7 +69,7 @@ export default composeBundles(
   }),
   createJwtApiBundle({
     root: process.env.REACT_APP_CUMULUS_API_URL,
-    unless: {
+    skipTokenConfig: {
       // GET requests do not include token unless path starts with /my_
       // Need token to figure out who "me" is
       custom: ({ method, path }) => {


### PR DESCRIPTION
Should fix issue #171 in the cumulus issues list, moving to the shared bundles lib broke the `unless` key.  I think that's why we're seeing weird caching issues, not really a caching issue, just the initial request was getting lost until you logged in.