### PR TITLE
Bugfix/jwt not included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cumulus-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cumulus-ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@headlessui/react": "^1.4.3",
         "@heroicons/react": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cumulus-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@headlessui/react": "^1.4.3",

--- a/src/app-bundles/index.js
+++ b/src/app-bundles/index.js
@@ -76,19 +76,21 @@ export default composeBundles(
       // GET requests do not include token unless path starts with /my_
       // Need token to figure out who "me" is
       custom: ({ method, url }) => {
-        // default to skipping the token
-        let ret = true;
+        // Skip including JWT Bearer Token on all GET requests UNLESS URL pathaname starts with /my_
+        // or it's defined in token_routes array
         if (method === 'GET') {
-          // Include Token on Any Routes that match any of the following patterns
-          const includeTokenFor = ['/my_', 'download'];
-          for (const path of includeTokenFor) {
-            if (url.indexOf(path) !== -1) {
-              ret = false;
-              break;
-            }
+          const urlObj = new URL(url);
+          const token_routes = {
+            '/my_downloads': true,
+            '/downloads': true,
+          };
+          if (urlObj.pathname && token_routes[urlObj.pathname]) {
+            return false;
           }
+          return true;
         }
-        return ret;
+        // Include JWT Bearer Token on all other requests
+        return false;
       },
     },
   })


### PR DESCRIPTION
borrowed code from workforce-ui.  two routes specified for GET are the only two that need tokens at the moment.